### PR TITLE
Fix Python and pip version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,13 +19,13 @@ RUN \
     libc6-dev-i386 \
     libx11-dev \
     gawk \
-    python-dev \
-    python-pip \
+    python3-dev \
+    python3-pip \
     curl \
     git
 
 # pip
-RUN pip install --upgrade pip
+RUN pip3 install --upgrade pip
 
 RUN mkdir $HOME/htk
 COPY . $HOME/htk/


### PR DESCRIPTION
Without this fix, I was getting
```
Collecting pip
  Downloading https://files.pythonhosted.org/packages/52/e1/06c018197d8151383f66ebf6979d951995cf495629fc54149491f5d157d0/pip-21.2.4.tar.gz (1.6MB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-VyYZxC/pip/setup.py", line 7
        def read(rel_path: str) -> str:
                         ^
    SyntaxError: invalid syntax

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-VyYZxC/pip/
You are using pip version 8.1.1, however version 21.2.4 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```